### PR TITLE
feat: remove Authorize attribute from GetDoorLocks in DoorLockController

### DIFF
--- a/WebAPI/FaceLock.WebAPI/Controllers/DoorLockController.cs
+++ b/WebAPI/FaceLock.WebAPI/Controllers/DoorLockController.cs
@@ -191,7 +191,6 @@ namespace FaceLock.WebAPI.Controllers
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(string))]
         [HttpGet("GetDoorLocks")]
-        [Authorize]
         public async Task<IActionResult> GetDoorLocks()
         {
             try


### PR DESCRIPTION
**Problem:**
Camera need to work independent of user authorization. Can't make request on api/Recognition/{doorLockId}/RecognizeUserForDoorLock because i can't get doors Ids without authorization.

**Feature:**
Get all doors IDs without authorization